### PR TITLE
Backlinks table + live query for DocsifyTemplate viewer

### DIFF
--- a/convex/backlinks.ts
+++ b/convex/backlinks.ts
@@ -1,0 +1,81 @@
+import { v } from 'convex/values'
+import { mutation, query } from './_generated/server'
+
+// Live query consumed by DocsifyTemplate viewer.
+// Returns a reverse index { target → [sources] } for the given project key.
+// Any mutation that touches the `backlinks` table re-fires this query on
+// every subscribed client automatically (Convex live queries, WS transport).
+export const getIndex = query({
+  args: { projectKey: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query('backlinks')
+      .withIndex('by_project_target', (q) => q.eq('projectKey', args.projectKey))
+      .collect()
+
+    const index: Record<string, string[]> = {}
+    for (const r of rows) {
+      ;(index[r.target] ||= []).push(r.source)
+    }
+    for (const k of Object.keys(index)) {
+      index[k] = [...new Set(index[k])].sort()
+    }
+    return index
+  },
+})
+
+// Replace all backlink rows coming FROM a given source doc with a new set of
+// targets. Idempotent — call with an empty `targets` array to clear.
+export const setForSource = mutation({
+  args: {
+    projectKey: v.string(),
+    source: v.string(),
+    targets: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const old = await ctx.db
+      .query('backlinks')
+      .withIndex('by_project_source', (q) =>
+        q.eq('projectKey', args.projectKey).eq('source', args.source),
+      )
+      .collect()
+    for (const r of old) await ctx.db.delete(r._id)
+
+    for (const t of args.targets) {
+      if (t === args.source) continue
+      await ctx.db.insert('backlinks', {
+        projectKey: args.projectKey,
+        source: args.source,
+        target: t,
+      })
+    }
+  },
+})
+
+// Seed helper for the POC — lets you populate the table from the Convex
+// dashboard or CLI without wiring documents.update yet. Accepts a full
+// forward map { source → [targets] } and rewrites every row for the project.
+export const seed = mutation({
+  args: {
+    projectKey: v.string(),
+    forward: v.record(v.string(), v.array(v.string())),
+  },
+  handler: async (ctx, args) => {
+    const old = await ctx.db
+      .query('backlinks')
+      .withIndex('by_project_target', (q) => q.eq('projectKey', args.projectKey))
+      .collect()
+    for (const r of old) await ctx.db.delete(r._id)
+
+    for (const [source, targets] of Object.entries(args.forward)) {
+      for (const target of targets) {
+        if (target === source) continue
+        await ctx.db.insert('backlinks', {
+          projectKey: args.projectKey,
+          source,
+          target,
+        })
+      }
+    }
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -31,4 +31,15 @@ export default defineSchema({
     avatarUrl: v.optional(v.string()),
     connectedAt: v.number(),
   }).index('by_userId', ['userId']),
+
+  // Reverse-link rows consumed by DocsifyTemplate viewers via live query.
+  // One row per (target, source) edge. `projectKey` lets multiple viewers
+  // share one deployment without needing a Convex project Id.
+  backlinks: defineTable({
+    projectKey: v.string(),
+    target: v.string(),
+    source: v.string(),
+  })
+    .index('by_project_target', ['projectKey', 'target'])
+    .index('by_project_source', ['projectKey', 'source']),
 })


### PR DESCRIPTION
## Summary

New Convex table + handlers that let any DocsifyTemplate viewer subscribe to a reactive reverse-link index over WebSocket. Companion to DocsifyTemplate PR #17.

**Table `backlinks`** — one row per (target, source) edge, scoped by `projectKey` string so non-Kiri clients can share the deployment without owning a Convex project row.

**Handlers:**
- \`getIndex(projectKey)\` — live query returning \`{target: [sources]}\`. Viewers subscribe via \`ConvexClient.onUpdate\` and pipe straight into a Preact signal. Any mutation re-fires automatically.
- \`setForSource(projectKey, source, targets)\` — idempotent upsert path. Intended to be called from \`documents.update\` once the viewer integration is proven.
- \`seed(projectKey, forward)\` — POC helper. Wipes + bulk-inserts the whole forward map. Lets you trigger live updates from the Convex dashboard before wiring anything to \`documents.update\`.

## How this fits Kiri

Kiri editor's React app already uses Convex for documents. This adds a parallel live-query path specifically for the public viewer (DocsifyTemplate), which was previously read-only from raw.githubusercontent.com. Next step (separate PR): call \`setForSource\` from \`documents.update\` so the graph rebuilds automatically when a PO edits a doc.

## Test plan

- [ ] \`npx convex dev --configure existing --dev-deployment cloud\` — deploys schema + handlers to cloud (local deployment unsupported on ARM/Termux)
- [ ] Seed: \`npx convex run backlinks:seed '{"projectKey":"docsify-demo","forward":{"/content/guide/architecture":["/content/guide/getting-started"]}}'\`
- [ ] In DocsifyTemplate viewer, uncomment the \`__convexConfig\` block in \`docs/index.html\` and reload
- [ ] Verify DevTools console: \`[convex-adapter] subscribed to backlinks:getIndex\`
- [ ] Navigate to \`/content/guide/getting-started\` — "Related pages" panel shows \`/content/guide/architecture\`
- [ ] Edit a row in Convex dashboard → panel updates in viewer within ~150ms without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive backlink tracking and management system for handling item reference relationships across projects.
  * Backend now supports both bulk initialization and incremental updates of backlink data for maintaining accurate references.
  * Reverse-index querying capability enables efficient discovery of all items referencing a specific target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->